### PR TITLE
Update for julia0.5

### DIFF
--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -41,7 +41,7 @@ function levenberg_marquardt(f::Function, g::Function, x0::Vector{Float64}; tolX
 		# Where we have used the equivalence: diagm(J'*J) = diagm(sum(J.^2, 1))
 		# It is additionally useful to bound the elements of DtD below to help
 		# prevent "parameter evaporation".
-		DtD = diagm(Float64[max(x, MIN_DIAGONAL) for x in sum(J.^2,1)])
+		DtD = diagm(vec(Float64[max(x, MIN_DIAGONAL) for x in sum(J.^2,1)]))
 		delta_x = ( J'*J + sqrt(lambda)*DtD ) \ -J'*fcur
 
 		# if the linear assumption is valid, our new residual should be:

--- a/src/science.jl
+++ b/src/science.jl
@@ -165,8 +165,8 @@ function fitdata(opts::Dict)
   # parallel workers are better than multithreaded BLAS for this problem
   # run julia with the '-p <n>' flag to start with n workers
   blas_set_num_threads(1)
-  startworkers(opts["workers"])
-  require("DCEMRI.jl")
+  # startworkers(opts["workers"])
+  # require("DCEMRI.jl")
 
   if haskey(opts, "R10") && haskey(opts, "S0")
     @dprint "found existing R1 map"

--- a/src/science.jl
+++ b/src/science.jl
@@ -164,7 +164,7 @@ function fitdata(opts::Dict)
 
   # parallel workers are better than multithreaded BLAS for this problem
   # run julia with the '-p <n>' flag to start with n workers
-  blas_set_num_threads(1)
+  BLAS.set_num_threads(1)
   # startworkers(opts["workers"])
   # require("DCEMRI.jl")
 
@@ -190,7 +190,7 @@ function fitdata(opts::Dict)
   # MAIN: run postprocessing steps
   SER = ser(dcedata)
   if haskey(opts, "mask") # if mask specified, use it
-      mask = bitpack(opts["mask"])
+      mask = BitArray(opts["mask"])
   else   # use SER threshold
       mask = SER .> opts["SERcutoff"]
   end
@@ -205,7 +205,7 @@ function fitdata(opts::Dict)
   results["R10"] = R10
   results["S0"] = S0
   results["SER"] = SER
-  results["mask"] = bitunpack(mask)
+  results["mask"] = Array(mask)
   results["models"] = models
   results["modelmap"] = modelmap
   results["R1"] = R1

--- a/src/util.jl
+++ b/src/util.jl
@@ -104,7 +104,7 @@ end
 
 # converts keyword argument to a dictionary
 function kwargs2dict(kwargs)
-    d = Dict{ASCIIString,Any}()
+    d = Dict{String,Any}()
     for (k, v) in kwargs
         d[string(k)] = v
     end


### PR DESCRIPTION
Few changes to make DCEMRI.jl compatible with Julia 0.5, since it seems that the move from 0.4 to 0.5 broke some stuff.

The main culprit is the removal of require(). My solution for now is to avoid needing require() by starting the worker cluster manually using addprocs() before loading the DCEMRI package.

The levenberg_marquardt() fitting function also broke for some reason. Seems that one of the column-vectors became a row-vector for some reason in 0.5, and diagm() does not like that.

There's also some deprecated warnings which were resolved. This updated version is working well for me in Julia 0.5.0, but these changes are not backwards-compatible (i.e. it no longer works properly on 0.4.5).

validate() still fails due to some errors at the plotting stage, but that seems to be an issue with pyplot and not with the fitting/results.