### PR TITLE
Speed improvement by changing convolution code

### DIFF
--- a/src/models.jl
+++ b/src/models.jl
@@ -7,24 +7,42 @@ function spgreqn(x::Vector{Float64}, p::Vector{Float64}, TR::Float64)
   y
 end
 
+function expConv(A::Vector{Float64}, B::Float64, t::Vector{Float64})
+  # Returns f = A ConvolvedWith exp(-B t)
+  # Based on Flouri et al. (2016) MRM 76(3), doi: 10.1002/mrm.25991
+  n = length(t)
+  x = B * ( t[2:n] - t[1:n-1] )
+  dA = ( A[2:n] - A[1:n-1] ) ./ x
+  E = exp(-x)
+  E0 = 1 - E
+  E1 = x - E0
+  iterAdd = A[1:n-1] .* E0 + dA .* E1;
+  f = zeros(n);
+  for i in 1:n-1
+     f[i+1] = E[i]*f[i] + iterAdd[i];
+  end
+  f = f / B;
+end
+
 function toftskety(t::Vector{Float64}, p::Vector{Float64}, Cp::Vector{Float64})
   # Standard Tofts-Kety Model.  Works when t_dce = t_aif only, so you should
   # resample the AIF to match the DCE dynamic spacing before using.
   Ct = zeros(t)
   kep = p[2]  # kep = Ktrans / ve
-  for k in 1:length(Ct)
-    #Ct[k] = p[1]*trapz(exp(-p[1]*(t[k] - t[1:k])/p[2]) .* Cp[1:k], t[1:k])
-    # inlined trapz here ... original equations are up here ^
-    tk = t[k]
-    @simd for j = 1:k
-      @inbounds y = exp(kep*(t[j] - tk)) * Cp[j]
-      @inbounds Ct[k] += ifelse((j == 1 || j == k) && k > 1, 0.5*y, y)
-    end
-  end
-  dtp = (t[2] - t[1]) * p[1]
-  @simd for k = 1:length(Ct)
-    @inbounds Ct[k] *= dtp
-  end
+  Ct = p[1] * expConv(Cp,kep,t)
+  #   for k in 1:length(Ct)
+  #     #Ct[k] = p[1]*trapz(exp(-p[1]*(t[k] - t[1:k])/p[2]) .* Cp[1:k], t[1:k])
+  #     # inlined trapz here ... original equations are up here ^
+  #     tk = t[k]
+  #     @simd for j = 1:k
+  #       @inbounds y = exp(kep*(t[j] - tk)) * Cp[j]
+  #       @inbounds Ct[k] += ifelse((j == 1 || j == k) && k > 1, 0.5*y, y)
+  #     end
+  #   end
+  #   dtp = (t[2] - t[1]) * p[1]
+  #   @simd for k = 1:length(Ct)
+  #     @inbounds Ct[k] *= dtp
+  #   end
   Ct
 end
 

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -25,7 +25,7 @@ function makeplots6(mat::Dict, outdir::AbstractString; dx=1)
   clf()
   plot(mat["t"], mat["Cp"], "ko-")
   xlabel("time (min)")
-  yticks([0:2:10])
+  # yticks([0:2:10]) # This produces an error
   ylim(0,10)
   ylabel("[Gd-DTPA] (mM)")
   title("arterial input function, \$C_p\$")

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -131,8 +131,8 @@ function makeplots4(mat::Dict, outdir::AbstractString; dx=1)
   back = (S0map - minimum(S0map)) / (maximum(S0map) - minimum(S0map))
   mask = convert(Array{Bool,2}, mat["mask"])
 
-  ytpos = [(div(10,dx)+floor(Integer, 5/dx)):div(30,dx):(div(180,dx)-1)]
-  xtpos = [(0+floor(Integer, 5/dx)):div(10,dx):(div(50,dx)-1)]
+  ytpos = collect((div(10,dx)+floor(Integer, 5/dx)):div(30,dx):(div(180,dx)-1))
+  xtpos = collect((0+floor(Integer, 5/dx)):div(10,dx):(div(50,dx)-1))
   ytlabels = [string(x) for x in [0.001, 0.005, 0.01, 0.02, 0.05, 0.1]]
   xtlabels = [string(x) for x in [0.01,0.02,0.05,0.1,0.2]]
 


### PR DESCRIPTION
There's two changes in this pull request.

The main change is that the convolution in the Tofts-Key Model is now performed using the algorithm detailed in the appendix of: 
Flouri, Lesnic, & Sourbron (2016). MRM 76(3), doi: 10.1002/mrm.25991.  
The new implementation provides a considerable improvement in speed without substantially changing the results - if anything, the errors are slightly smaller in noiseless QIBA 6 data. 

At the bottom, I've included the summary statistics to compare the old version and the new convolution implementation. 
The big change is the runtime which was calculated by running the fit 6 times, and then taking the mean +/- stdDev of the runtime from the last five fits - the first runtime is discarded because it is generally slower than the rest.

The second change is minor and involves commenting out one line which was causing `validate(6)` to fail. Commenting it out resolved the problem and `validate(6)` now runs successfully for me on Julia 0.5.2.
There is still a problem with `validate(4)` - I think it's the lines involving 'xticks' and maybe also 'yticks'. 
I'm not sure if this is a general problem or if it's just a problem on my end, so I didn't touch `validate(4)`.

**Comparison between Old and New convolution implementation**

**1. QIBA 6 - Noiseless**  
(1321 x 30 points on one CPU core)

**Term**|**Old**|**New**
-----|-----|-----
Kt RMSE|0.42|0.06
Kt max|2.17|0.14
Kt CCC|0.99993|0.99999
ve RMSE|0.13|0.08
ve max|0.57|0.23
ve CCC|0.999999374|0.999999376
Runtime[s]|26.6 +/- 0.2|0.36 +/- 0.09

**2. QIBA 6 - Noisy**  
(1321 x 3000 points on one CPU core)

**Term**|**New**
-----|-----
Kt RMSE|21.4
Kt max|100
Kt CCC|0.8508
ve RMSE|16.06
ve max|100
ve CCC|0.8707
Runtime[s]|26.2

* This takes much longer using the 'old' method, so I skipped it. I'm assuming you have values from a previous validation run, which can be compared against these values.

**3. QIBA 4 - Noiseless**  
(661 x 90 points on one CPU core)

**Term**|**Old**|**New**
-----|-----|-----
Kt RMSE|6.974653262|6.974660651
Kt max|23.49363809|23.49362108
Kt CCC|0.999800984|0.999800811
ve RMSE|18.02170569|18.02171367
ve max|100|100
ve CCC|0.890429062|0.890429128
vp RMSE|23.77019514|23.80389152
vp max|92.10582798|92.5412823
vp CCC|0.999920099|0.999919898
Runtime[s]|20.9 +/- 0.2|0.5