### PR TITLE
Fixed linearized tofts models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pdf
 *.png
+
+# Exclude the validation results
+/test/q4/results*
+/test/q6/results*

--- a/test/linearTests.jl
+++ b/test/linearTests.jl
@@ -1,0 +1,36 @@
+# This script validate the linearized tofts models
+
+using MAT
+using DCEMRI
+
+# List of tests to run, in pairs
+# First run is noiseless, second run is with noise
+nList = collect([6,6,4,4])
+
+for i = 1:length(nList)
+  n=nList[i]
+  # Move to test directory
+  cd(Pkg.dir("DCEMRI/test/q$n"))
+
+  # Define the input and output file/directory
+  curDx = 1
+  if mod(i,2)==1
+    datafile="qiba$n.mat"
+    outdir = Pkg.dir("DCEMRI/test/q$n") * "\\results"
+    curDx = 10
+  else
+    datafile="qiba$(n)noisy.mat"
+    outdir = Pkg.dir("DCEMRI/test/q$n") * "\\results_noisy"
+  end
+  isdir(outdir) || mkdir(outdir)
+
+  models=[4]
+  if n==4
+    models=[5]
+  end
+
+  results = fitdata(datafile=datafile, outfile=outdir * "/results.mat", models=models)
+
+  # Make plots and calculate summary statistics
+  DCEMRI.analyze(n, results, outdir; dx=curDx)
+end


### PR DESCRIPTION
This fix addresses issue #34.
Problem was that the linearized models estimates are [Ktrans, kep, vp], but the package prefers [Ktrans, ve, vp]. 

I've included the script used to test the models along with the summary statistics at the bottom. 
The linear model struggles at very low ve values, which is why it has comparatively poor accuracy on the QIBA 6 phantom (it struggles to fit ve=0.01). 
The QIBA 4 phantom has much larger ve values (all ve are >= 0.1), so the linearized models perform about as well as the non-linear approach.

Unrelated change: added the validation's output folder into .gitignore so that I don't have to delete the output before commiting.

---

**QIBA 6 - Noiseless**  
 (1321 x 30 points)

 | |**NonLin**|**Lin**
-----|-----|-----
Runtime [s]|1.8|0.4
Kt RMSE|0.059|1.082
Kt errMax|0.123|4.978
Kt CCC|0.9999|0.9996
Ve RMSE|0.082|0.106
Ve errMax|0.234|0.263
Ve CCC|0.9999|0.9999

**QIBA 6 - Noisy**   
(1321 x 3000 points)

| |**NonLin**|**Lin**
-----|-----|-----
Runtime [s]|15.8|0.99
Kt RMSE|21.33|38.84
Kt errMax|100|100
Kt CCC|0.845|0.659
Ve RMSE|16.14|18.38
Ve errMax|100|100
Ve CCC|0.862|0.835

**QIBA 4 - Noiseless**   
(661 x 90 points)

| |**NonLin**|**Lin**
-----|-----|-----
Runtime [s]|0.6|0.03
Kt RMSE|6.97|7.05
Kt errMax|23.49|23.7
Kt CCC|0.9998|0.9995
Ve RMSE|18.02|18.03
Ve errMax|99.99|99.99
Ve CCC|0.8904|0.8903
Vp RMSE|23.8|25.23
Vp errMax|92.53|100
Vp CCC|0.9999|0.9999

**QIBA 4 - Noisy**  
 (661 x 9000 points)

| |**NonLin**|**Lin**
-----|-----|-----
Runtime [s]|23.2|1.7
Kt RMSE|11.31|11.4
Kt errMax|100|100
Kt CCC|0.9742|0.9718
Ve RMSE|18.26|18.31
Ve errMax|100|100
Ve CCC|0.7021|0.7008
Vp RMSE|12.68|13.27
Vp errMax|100|100
Vp CCC|0.9717|0.9702