### PR TITLE
Update for Julia 0.7/1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ julia:
 #    - julia -e 'Pkg.init(); Pkg.clone(pwd())'
 #    - julia -e 'Pkg.test("DCEMRI", coverage=true)'
 after_success:
-    - julia -e 'cd(Pkg.dir("DCEMRI")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-    - julia -e 'cd(Pkg.dir("DCEMRI")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+    - julia -e 'using Pkg; import DCEMRI; cd(joinpath(dirname(pathof(DCEMRI)),"../")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - julia -e 'using Pkg; import DCEMRI; cd(joinpath(dirname(pathof(DCEMRI)),"../")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: julia
 notifications:
     email: false
 julia:
-    - 0.6
+    - 0.7
+    - 1.0
     - nightly
 #script: # use the default script which is equivalent to the following
 #    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
-julia 0.6
+julia 0.7
 ArgParse
 Calculus
 MAT
+LsqFit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,43 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
     - master
     - /release-.*/
-install:
-# Download most recent Julia Windows binary
 
-  - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-#  - git fetch --unshallow
-  - C:\projects\julia\bin\julia-debug -e "versioninfo(); Pkg.clone(pwd(), \"DCEMRI\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia-debug -e "Pkg.test(\"DCEMRI\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/DCEMRI.jl
+++ b/src/DCEMRI.jl
@@ -3,6 +3,7 @@ module DCEMRI
 using ArgParse
 using Calculus    #.jacobian
 using MAT
+using Pkg, LinearAlgebra, Random, Statistics, Distributed, Printf, LsqFit
 
 export ser, r1eff, tissueconc, fitr1, fitdce, fitdata,
   defaults, ccc, nlsfit, makeplots, demo, validate
@@ -10,10 +11,10 @@ export ser, r1eff, tissueconc, fitr1, fitdce, fitdata,
 const verbose = true
 const version = v"0.1.2"
 
-if Pkg.installed("PyPlot")==Void()
-  # println("Optional package (PyPlot) not installed.")
+if haskey(Pkg.installed(),"PyPlot")
+    using PyPlot
 else
-  using PyPlot
+    # println("Optional package (PyPlot) not installed.")
 end
 
 include("util.jl")

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -1,188 +1,20 @@
-
-# levenberg_marquart() is taken from the LsqFit.jl package. The original
-# license for that code is:
-#
-# Copyright (c) 2012: John Myles White and other contributors.
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-function levenberg_marquardt{T}( f::Function, g::Function, initial_x::AbstractVector{T};
-    tolX::Real = 1e-8, tolG::Real = 1e-12, maxIter::Integer = 100,
-    lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
-    min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
-    show_trace::Bool = false, lower::Vector{T} = Array{T}(0), upper::Vector{T} = Array{T}(0))
-	# finds argmin sum(f(x).^2) using the Levenberg-Marquardt algorithm
-	#          x
-	# The function f should take an input vector of length n and return an output vector of length m
-	# The function g is the Jacobian of f, and should be an m x n matrix
-	# initial_x is an initial guess for the solution
-	# fargs is a tuple of additional arguments to pass to f
-	# available options:
-	#   tolX - search tolerance in x
-	#   tolG - search tolerance in gradient
-	#   maxIter - maximum number of iterations
-	#   lambda - (inverse of) initial trust region radius
-	#   show_trace - print a status summary on each iteration if true
-	# returns: x, J
-	#   x - least squares solution for x
-	#   J - estimate of the Jacobian of f at x
-    # check parameters
-    ((isempty(lower) || length(lower)==length(initial_x)) && (isempty(upper) || length(upper)==length(initial_x))) ||
-            throw(ArgumentError("Bounds must either be empty or of the same length as the number of parameters."))
-    ((isempty(lower) || all(initial_x .>= lower)) && (isempty(upper) || all(initial_x .<= upper))) ||
-            throw(ArgumentError("Initial guess must be within bounds."))
-    (0 <= min_step_quality < 1) || throw(ArgumentError(" 0 <= min_step_quality < 1 must hold."))
-    (0 < good_step_quality <= 1) || throw(ArgumentError(" 0 < good_step_quality <= 1 must hold."))
-    (min_step_quality < good_step_quality) || throw(ArgumentError("min_step_quality < good_step_quality must hold."))
-
-
-	const MAX_LAMBDA = 1e16 # minimum trust region radius
-	const MIN_LAMBDA = 1e-16 # maximum trust region radius
-	const MIN_DIAGONAL = 1e-6 # lower bound on values of diagonal matrix used to regularize the trust region step
-	converged = false
-    x_converged = false
-    g_converged = false
-    need_jacobian = true
-	iterCt = 0
-	x = copy(initial_x)
-	delta_x = copy(initial_x)
-	f_calls = 0
-	g_calls = 0
-	fcur = f(x)
-	f_calls += 1
-	residual = sum(abs2, fcur)
-
-    # Create buffers
-    n = length(x)
-    JJ = Matrix{T}(n, n)
-    n_buffer = Vector{T}(n)
-
-	while ~converged && iterCt < maxIter
-        if need_jacobian
-            J = g(x)
-            g_calls += 1
-            need_jacobian = false
-        end
-		# we want to solve:
-		#    argmin 0.5*||J(x)*delta_x + f(x)||^2 + lambda*||diagm(J'*J)*delta_x||^2
-		# Solving for the minimum gives:
-		#    (J'*J + lambda*DtD) * delta_x == -J^T * f(x), where DtD = diagm(sum(J.^2,1))
-		# Where we have used the equivalence: diagm(J'*J) = diagm(sum(J.^2, 1))
-		# It is additionally useful to bound the elements of DtD below to help
-		# prevent "parameter evaporation".
-
-		# REPLACED: DtD = diagm(vec(Float64[max(x, MIN_DIAGONAL) for x in sum(J.^2,1)]))
-        DtD = vec(sum(abs2, J, 1))
-        for i in 1:length(DtD)
-            if DtD[i] <= MIN_DIAGONAL
-                DtD[i] = MIN_DIAGONAL
-            end
-        end
-
-		# REPLACED: delta_x = ( J'*J + sqrt(lambda)*DtD ) \ -J'*fcur
-        At_mul_B!(JJ, J, J)
-        @simd for i in 1:n
-            @inbounds JJ[i, i] += lambda * DtD[i]
-        end
-        At_mul_B!(n_buffer, J, fcur)
-        scale!(n_buffer, -1)
-        delta_x = JJ \ n_buffer
-
-        # apply box constraints
-        if !isempty(lower)
-            @simd for i in 1:n
-              @inbounds delta_x[i] = max(x[i] + delta_x[i], lower[i]) - x[i]
-            end
-        end
-        if !isempty(upper)
-            @simd for i in 1:n
-               @inbounds delta_x[i] = min(x[i] + delta_x[i], upper[i]) - x[i]
-            end
-        end
-
-		# if the linear assumption is valid, our new residual should be:
-		# REPLACED: predicted_residual = norm(J*delta_x + fcur)^2
-        predicted_residual = sum(abs2, J*delta_x + fcur)
-
-		# check for numerical problems in solving for delta_x by ensuring that the predicted residual is smaller
-		# than the current residual
-		if predicted_residual > residual + 2max(eps(predicted_residual),eps(residual))
-			warn("""Problem solving for delta_x: predicted residual increase.
-                             $predicted_residual (predicted_residual) >
-                             $residual (residual) + $(eps(predicted_residual)) (eps)""")
-		end
-
-        # try the step and compute its quality
-        trial_f = f(x + delta_x)
-        f_calls += 1
-        trial_residual = sum(abs2, trial_f)
-        # step quality = residual change / predicted residual change
-        rho = (trial_residual - residual) / (predicted_residual - residual)
-        if rho > min_step_quality
-            x += delta_x
-            fcur = trial_f
-            residual = trial_residual
-            if rho > good_step_quality
-                # increase trust region radius
-                lambda = max(lambda_decrease*lambda, MIN_LAMBDA)
-            end
-            need_jacobian = true
-        else
-            # decrease trust region radius
-            lambda = min(lambda_increase*lambda, MAX_LAMBDA)
-        end
-        iterCt += 1
-
-		# check convergence criteria:
-		# 1. Small gradient: norm(J^T * fcur, Inf) < tolG
-		# 2. Small step size: norm(delta_x) < tolX
-		# REPLACED: converged = (norm(J' * fcur, Inf) < tolG) || (norm(delta_x) < tolX*(tolX + norm(x)))
-        if norm(J' * fcur, Inf) < tolG
-            g_converged = true
-        elseif norm(delta_x) < tolX*(tolX + norm(x))
-            x_converged = true
-        end
-        converged = g_converged | x_converged
-	end
-	return x
-end
-
-function nlsfitworker{T}(model::Function, y::Matrix{T}, x::Vector{T}, p0::Vector{T}; kwargs...)
+function nlsfitworker(model::Function, y::Matrix{T}, x::Vector{T}, p0::Vector{T}; kwargs...) where T
   # performs Levenberg-Marquardt fitting
   nparams = length(p0)
   n = size(y,2)
   params = zeros(nparams, n)
   resids = similar(y)
   for j in 1:n
-    f(p) = model(x, p) - y[:,j]
-    g = Calculus.jacobian(f, :forward)
-    results = levenberg_marquardt(f, g, p0; tolX=1e-3, tolG=1e-4, lambda=10.0, kwargs...)
-    resids[:,j] = f(results) / sqrt(norm(y[:,j]))
-    params[:,j] = results
+    fit = curve_fit(model, x, y[:,j], p0)
+    params[:,j] = fit.param
+    resids[:,j] = fit.resid
   end
   (params, resids)
 end
 
-function nlsfit{T}(f::Function, y::Matrix{T}, idxs::Vector{Int}, x::Vector{T},
-  p0::Vector{T}; kwargs...)
-  tic()
+function nlsfit(f::Function, y::Matrix{T}, idxs::Vector{Int}, x::Vector{T},
+  p0::Vector{T}; kwargs...) where T
+  timerStart = time_ns()
   nt, n = size(y)
   nw = nworkers()
   nidxs = length(idxs)
@@ -207,7 +39,7 @@ function nlsfit{T}(f::Function, y::Matrix{T}, idxs::Vector{Int}, x::Vector{T},
     @dprint "running $nt x $nidxs points on one CPU core"
     params[:,idxs], resids[:,idxs] = nlsfitworker(f, y[:,idxs], x, p0; kwargs...)
   end
-  t = toq()
+  t = (time_ns()-timerStart)/1e9
   vps = nidxs / t
   @dprint @sprintf "processed %d voxels in %.1f s (%.1f vox/s)\n" nidxs t vps
   (params, resids, dof)

--- a/src/models.jl
+++ b/src/models.jl
@@ -10,16 +10,14 @@ end
 function expConv(A::Vector{Float64}, B::Float64, t::Vector{Float64})
   # Returns f = A ConvolvedWith exp(-B t)
   # Based on Flouri et al. (2016) MRM 76(3), doi: 10.1002/mrm.25991
-  n = length(t)
-  x = B * ( t[2:n] - t[1:n-1] )
-  dA = ( A[2:n] - A[1:n-1] ) ./ x
-  E = exp.(-x)
-  E0 = 1 .- E
-  E1 = x - E0
-  iterAdd = A[1:n-1] .* E0 + dA .* E1
-  f = zeros(n)
-  for i in 1:n-1
-     f[i+1] = E[i]*f[i] + iterAdd[i]
+  f = zeros(length(t))
+  for i in 1:length(t)-1
+        x = B * ( t[i+1] - t[i] )
+        dA = ( A[i+1] - A[i] ) / x
+        E = exp(-x)
+        E0 = 1 - E
+        E1 = x - E0
+        f[i+1] = E*f[i] + A[i] * E0 + dA * E1
   end
   f = f / B
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -14,7 +14,7 @@ function expConv(A::Vector{Float64}, B::Float64, t::Vector{Float64})
   x = B * ( t[2:n] - t[1:n-1] )
   dA = ( A[2:n] - A[1:n-1] ) ./ x
   E = exp.(-x)
-  E0 = 1 - E
+  E0 = 1 .- E
   E1 = x - E0
   iterAdd = A[1:n-1] .* E0 + dA .* E1
   f = zeros(n)
@@ -27,7 +27,7 @@ end
 function toftskety(t::Vector{Float64}, p::Vector{Float64}, Cp::Vector{Float64})
   # Standard Tofts-Kety Model.  Works when t_dce = t_aif only, so you should
   # resample the AIF to match the DCE dynamic spacing before using.
-  Ct = zeros(t)
+  Ct = zero(t)
   kep = p[2]  # kep = Ktrans / ve
   Ct = p[1] * expConv(Cp,kep,t)
   #   for k in 1:length(Ct)

--- a/src/util.jl
+++ b/src/util.jl
@@ -93,13 +93,13 @@ function validate(d::Dict)
   @assert (haskey(d,"R10") && haskey(d,"S0")) || (haskey(d,"T1data") && haskey(d,"T1flip")) "Input must contain either R10+S0 or T1data+T1flip."
 end
 
-function ccc{T,N}(x::Array{T,N}, y::Array{T,N})
+function ccc(x::Array{T,N}, y::Array{T,N}) where {T, N}
   # concordance correlation coefficient
   m1 = mean(x)
   m2 = mean(y)
   s1 = var(x)*(length(x) - 1.0) / length(x)
   s2 = var(y)*(length(y) - 1.0) / length(y)
-  s12 = sum((x - m1).*(y - m2)) / length(x)
+  s12 = sum((x .- m1).*(y .- m2)) / length(x)
   2s12 / (s1 + s2 + (m1 - m2).^2)
 end
 
@@ -110,4 +110,8 @@ function kwargs2dict(kwargs)
         d[string(k)] = v
     end
     d
+end
+
+function find(A::AbstractArray)
+  (LinearIndices(A))[findall(x->x!=0, A)]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 # units tests.
-using Base.Test
+using Test
 using DCEMRI
 
 ccc4, cccnoisy4 = validate(4, makeplots=false)
@@ -7,16 +7,15 @@ ccc4, cccnoisy4 = validate(4, makeplots=false)
   @test ccc4[1] >= 0.9998
   @test ccc4[2] >= 0.8904
   @test ccc4[3] >= 0.9999
-  @test signif(cccnoisy4[1],2) >= 0.97
-  @test signif(cccnoisy4[2],2) >= 0.70
-  @test signif(cccnoisy4[3],2) >= 0.97
+  @test round(cccnoisy4[1], sigdigits=2) >= 0.97
+  @test round(cccnoisy4[2], sigdigits=2) >= 0.70
+  @test round(cccnoisy4[3], sigdigits=2) >= 0.97
 end
 
 ccc6, cccnoisy6 = validate(6, makeplots=false)
 @testset "QIBA v6 Standard Tofts Phantom" begin
   @test ccc6[1] >= 0.9999
   @test ccc6[2] >= 0.9999
-  @test signif(cccnoisy6[1],2) >= 0.84
-  @test signif(cccnoisy6[2],2) >= 0.86
+  @test round(cccnoisy6[1], sigdigits=2) >= 0.84
+  @test round(cccnoisy6[2], sigdigits=2) >= 0.86
 end
-


### PR DESCRIPTION
Changes:

- Fixed deprecated syntax
- Kept updated ExpConv() function from PR #43 
    + For some reason, it now passes the unit tests whereas it failed before 😕 
- Added [LsqFit.jl](https://github.com/JuliaNLSolvers/LsqFit.jl) for the non-linear fitting
    + Because LevMarq function wasn't working and it was easier to switch to LsqFit than to debug it (was there a reason for extracting LevMarq from LsqFit instead of using the package?)

One unresolved issue is that the new Pkg3 broke the optional PyPlot that was introduced in PR #40.
In the past, Julia didn't check whether a used package was mentioned in `REQUIRE`, but it does now. 
Things work fine if PyPlot isn't installed, but if PyPlot is installed, then an error is thrown because DCEMRI tries to load PyPlot without mentioning it as a dependency. 
The new TOML-based configuration might make it possible to define optional dependencies, but I'm not up to speed on its workings.

The are other upstream warnings, mostly related to MAT.jl. 
The tests only pass on Julia 0.7 for now [(at least for me)](https://travis-ci.org/notZaki/DCEMRI.jl/builds/414844462), because 1.0 makes the warnings lethal. 
