### PR TITLE
Add dependencies for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: julia
 julia:
     - 1.0
     - nightly
+before_install:
+    - sudo apt-get install python3-matplotlib
 after_success:
     - julia -e 'cd(Pkg.dir("DCEMRI")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
 ## uncomment the following lines to override the default test script
-script:
- - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'
+#script:
+# - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,20 @@
 name = "DCEMRI"
 uuid = "2b3899e7-9068-5c5c-a4f4-f7d195ee295c"
-version = "0.2.1"
 author = ["David S. Smith <david.smith@gmail.com>"]
+version = "0.2.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
-MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
+MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]


### PR DESCRIPTION
I was checking some old code and the tests kept failing. This PR should hopefully make the Travis tests pass.

---

**Changes:**

- Add dependencies to `Project.toml`
    + This was done somewhat manually by navigating to the project directory and then:
    ```
     Julia>]activate .
     Julia>]add <dependencyNameOneByOne>
    ```
    + Alternatively, I think `]resolve` would've done the same thing
- Travis uses the installed python version and so matplotlib needs to be installed for it. There might be a way to force it to use the `Conda.jl`, but I didn't have time to figure it out.
- I (re?)commented that script section in `.travis.yml` to enable the default test script. I think the default script is better at handling different Julia versions, but I also don't know if there was a reason why it was overridden in the first place.
