### PR TITLE
Update linearized models for Julia 1.0

### DIFF
--- a/src/models.jl
+++ b/src/models.jl
@@ -76,7 +76,7 @@ function fitTM(t::Vector{Float64}, Ct::Matrix{Float64}, Cp::Vector{Float64})
       pkParams[:,i] = M\Ct[:,i]
       resid[:,i] = (M*pkParams[:,i]-Ct[:,i]) / sqrt(norm(Ct[:,i]))
   end
-  r = squeeze(sum(abs2,resid,1),1) / (sT-2)
+  r = sum(resid.^2, dims=1) ./ (sT-2)
   (pkParams, r)
 end
 
@@ -96,6 +96,6 @@ function fitETM(t::Vector{Float64}, Ct::Matrix{Float64}, Cp::Vector{Float64})
       resid[:,i] = (M*pkParams[:,i]-Ct[:,i]) / sqrt(norm(Ct[:,i]))
   end
   pkParams[1,:] = pkParams[1,:] - pkParams[2,:] .* pkParams[3,:]
-  r = squeeze(sum(abs2,resid,1),1) / (sT-3)
+  r = sum(resid.^2, dims=1) ./ (sT-3)
   (pkParams, r)
 end


### PR DESCRIPTION
This PR updates the linearized models which were still using some of the older syntax. 

The script in `./test/linearTests.jl` can be used to verify that the models work.
These tests were never part of the main testing suite, but I suppose they could be added by appending 
```julia
@testset "Linearized models" begin
  include(joinpath(@__DIR__, "linearTests.jl"))
end
```
to `./test/runtests.jl`.
